### PR TITLE
Add SMID postprocessing

### DIFF
--- a/src/curies_processing/rules.json
+++ b/src/curies_processing/rules.json
@@ -312,6 +312,13 @@
       ".svg"
     ]
   },
+  "postprocessing": {
+    "suffix": {
+      "smid": [
+        "%0D"
+      ]
+    }
+  },
   "rewrites": {
     "full": {
       "ABBREVIATION": "omo:0003000",
@@ -912,13 +919,6 @@
         "specificities:": "obo:xlmod#specificities",
         "waveLengthRange:": "obo:xlmod#waveLengthRange"
       }
-    }
-  },
-  "postprocessing": {
-    "suffix": {
-      "smid": [
-        "%0D"
-      ]
     }
   }
 }

--- a/src/curies_processing/rules.json
+++ b/src/curies_processing/rules.json
@@ -913,5 +913,12 @@
         "waveLengthRange:": "obo:xlmod#waveLengthRange"
       }
     }
+  },
+  "postprocessing": {
+    "suffix": {
+      "smid": [
+        "%0D"
+      ]
+    }
   }
 }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -14,6 +14,7 @@ class TestAPI(unittest.TestCase):
         """Test wrapping a converter."""
         c = curies.get_obo_converter()
         c.add_prefix("NLXDYS", "http://uri.neuinfo.org/nif/nifstd/nlx_dys_")
+        c.add_prefix("smid", "https://smid-db.org/detail/")
         c = curies_processing.wrap(c)
 
         r1 = c.parse("GOC:CJM", strict=True)
@@ -23,3 +24,8 @@ class TestAPI(unittest.TestCase):
         r2 = c.parse("NIFSTD:nlx_dys_20090602", strict=True)
         self.assertEqual("NLXDYS", r2.prefix)
         self.assertEqual("20090602", r2.identifier)
+
+        # test processing suffix
+        r3 = c.parse("smid:bhos%2322%0D")
+        self.assertEqual("smid", r3.prefix)
+        self.assertEqual("bhos%2322", r3.identifier)


### PR DESCRIPTION
In ChEBI, SMID references often come with this extra character at the end

https://smid-db.org/detail/ascr%2321